### PR TITLE
Metadata parsing precision

### DIFF
--- a/sarxarray/_io.py
+++ b/sarxarray/_io.py
@@ -460,7 +460,7 @@ def _regulate_metadata(metadata, driver):
     for time in metadata[TIME_STAMP_KEY]:
         try:
             dt = datetime.strptime(time, time_format)
-            list_time.append(np.datetime64(dt).astype("datetime64[s]"))
+            list_time.append(np.datetime64(dt).astype("datetime64[ns]"))
         except ValueError as e:
             raise ValueError(
                 f"Invalid date format for key: '{TIME_STAMP_KEY}'. "

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -228,6 +228,12 @@ class TestReadMetadata:
                 assert isinstance(metadata[key], int)
         assert np.isscalar(metadata["first_azimuth_time"])
 
+        # Check the time parsing precision
+        time_diff = abs(
+            metadata["first_azimuth_time"] - np.datetime64("2018-03-01T17:19:09.165")
+        )
+        assert time_diff <= np.timedelta64(1, "ns")
+
     def test_read_metadata_doris5_onefile(self, res_files_doris5, caplog):
         metadata = sarxarray.read_metadata(res_files_doris5[0], driver="doris5")
         for key in RE_PATTERNS_DORIS5.keys():
@@ -248,6 +254,12 @@ class TestReadMetadata:
                 assert isinstance(metadata[key], int)
         assert np.isscalar(metadata["first_azimuth_time"])
 
+        # Check the time parsing precision
+        time_diff = abs(
+            metadata["first_azimuth_time"] - np.datetime64("2018-03-06T17:24:29.95498")
+        )
+        assert time_diff <= np.timedelta64(1, "ns")
+
     def test_read_metadata_doris5_onefile_values(self, res_files_doris5):
         metadata = sarxarray.read_metadata(res_files_doris5[0], driver="doris5")
         assert metadata["sar_processor"] == "Sentinel-1B"
@@ -256,16 +268,16 @@ class TestReadMetadata:
         assert metadata["swath"] == "IW3"
         assert metadata["image_mode"] == "IW"
         assert metadata["polarisation"] == "VV"
-        assert np.isclose(metadata["range_pixel_spacing"], 2.329562e+00)
-        assert np.isclose(metadata["azimuth_pixel_spacing"], 1.385502e+01)
-        assert np.isclose(metadata["radar_frequency"], 5.405000454334350e+09)
+        assert np.isclose(metadata["range_pixel_spacing"], 2.329562e00)
+        assert np.isclose(metadata["azimuth_pixel_spacing"], 1.385502e01)
+        assert np.isclose(metadata["radar_frequency"], 5.405000454334350e09)
         assert metadata["sensor_platform"] == "S1B"
         assert np.isclose(metadata["wavelength"], 0.055465760)
         assert isinstance(metadata["first_azimuth_time"], np.datetime64)
         assert np.isclose(metadata["azimuth_time_interval"], 2.055556299999998e-03)
-        assert np.isclose(metadata["total_azimuth_bandwidth"], 3.140000000000000e+02)
+        assert np.isclose(metadata["total_azimuth_bandwidth"], 3.140000000000000e02)
         assert metadata["weighting_azimuth"] == "Hamming"
-        assert np.isclose(metadata["first_range_time"], 6.013024343276740/1000)
+        assert np.isclose(metadata["first_range_time"], 6.013024343276740 / 1000)
         assert np.isclose(metadata["range_sampling_rate"], 64.345238126 * 1_000_000)
         assert np.isclose(metadata["total_range_bandwidth"], 42.789918403 * 1_000_000)
         assert metadata["weighting_range"] == "Hamming"
@@ -277,5 +289,5 @@ class TestReadMetadata:
         assert np.isclose(metadata["scene_centre_longitude"], 6.557386154885761)
         assert np.allclose(
             metadata["orbit_txyz"][0],
-            [62569, 4954320.931616273, 78580.69269184131, 5042109.736565054]
+            [62569, 4954320.931616273, 78580.69269184131, 5042109.736565054],
         )


### PR DESCRIPTION
Fix the time parsing precision issue. The time strings are now parsed and store as `np.datetime64[ns]`