### PR TITLE
64 Native cropping in radar coordinates

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "numpy",
     "distributed",
     "zarr",
+    "shapely",
 ]
 description = "Xarray extension for Synthetic Aperture Radar (SAR) data"
 readme = "README.md"

--- a/sarxarray/utils.py
+++ b/sarxarray/utils.py
@@ -156,14 +156,15 @@ def complex_coherence(
 
 
 def crop(data: xr.Dataset | xr.DataArray, geom: sg.Polygon) -> xr.Dataset:
-    """Crop a radar image or stack of radar images to the bounding box of an area of interest.
+    """Crop a radar image or stack of radar images to the bounding box of a polygon.
 
     Parameters
     ----------
     data: xr.Dataset | xr.DataArray
         The dataset or data array to be cropped in azimuth and range
     geom: sg.Polygon
-        shapely.geometry.Polygon in radar coordinates of the area that should be kept, in [azimuth, range] format
+        shapely.geometry.Polygon in radar coordinates of the area that should be
+        kept, in [azimuth, range] format
 
     Returns
     -------
@@ -179,7 +180,10 @@ def crop(data: xr.Dataset | xr.DataArray, geom: sg.Polygon) -> xr.Dataset:
         raise ValueError("The data must have azimuth and range dimensions.")
 
     bounding_box = geom.bounds  # returns (min_az, min_r, max_az, max_r)
-    data = data.sel(azimuth=range(bounding_box[0], bounding_box[2]+1), range=range(bounding_box[1], bounding_box[3]+1))
+    data = data.sel(
+        azimuth=range(bounding_box[0], bounding_box[2]+1),
+        range=range(bounding_box[1], bounding_box[3]+1)
+    )
 
     return data
 

--- a/sarxarray/utils.py
+++ b/sarxarray/utils.py
@@ -155,16 +155,17 @@ def complex_coherence(
     return coherence
 
 
-def crop(data: xr.Dataset | xr.DataArray, geom: sg.Polygon) -> xr.Dataset:
+def crop(data: xr.Dataset | xr.DataArray, geom: sg.Polygon | tuple) -> xr.Dataset:
     """Crop a radar image or stack of radar images to the bounding box of a polygon.
 
     Parameters
     ----------
     data: xr.Dataset | xr.DataArray
         The dataset or data array to be cropped in azimuth and range
-    geom: sg.Polygon
+    geom: sg.Polygon | tuple
         shapely.geometry.Polygon in radar coordinates of the area that should be
-        kept, in [azimuth, range] format
+        kept, in [azimuth, range] format, OR a tuple of the bounding box of the crop in
+        (min_azimuth, min_range, max_azimuth, max_range) format
 
     Returns
     -------
@@ -174,12 +175,31 @@ def crop(data: xr.Dataset | xr.DataArray, geom: sg.Polygon) -> xr.Dataset:
     Raises
     ------
     ValueError
-        If the azimuth or range coordinate does not exist in `data`
+        - If the azimuth or range coordinate does not exist in `data`
+        - If `geom` is not `shapely.geometry.Polygon` or `tuple`
+
+    AssertionError
+        - When a tuple is passed to `geom` that falls in one of three categories:
+          - The tuple does not have exactly 4 entries
+          - The minimum azimuth coordinate is larger than or equal
+               to the maximum azimuth coordinate
+          - The minimum range coordinate is larger than or equal
+               to the maximum range coordinate
     """
     if not {"azimuth", "range"}.issubset(data.dims):
         raise ValueError("The data must have azimuth and range dimensions.")
 
-    bounding_box = geom.bounds  # returns (min_az, min_r, max_az, max_r)
+    if isinstance(geom, sg.Polygon):
+        bounding_box = geom.bounds  # returns (min_az, min_r, max_az, max_r)
+    elif isinstance(geom, tuple):
+        assert len(geom) == 4, f"geom as tuple must have four entries, got {len(geom)}"
+        assert geom[0] < geom[2], f"geom Azimuth wrong: min {geom[0]} >= max {geom[2]}"
+        assert geom[1] < geom[3], f"geom Range wrong: min {geom[1]} >= max {geom[3]}"
+        bounding_box = geom
+    else:
+        raise ValueError(
+            f"geom must be tuple or shapely.geometry.Polygon, is {type(geom)}."
+        )
     data = data.sel(
         azimuth=range(int(bounding_box[0]), int(np.ceil(bounding_box[2]))+1),
         range=range(int(bounding_box[1]), int(np.ceil(bounding_box[3]))+1)

--- a/sarxarray/utils.py
+++ b/sarxarray/utils.py
@@ -1,4 +1,5 @@
 import numpy as np
+import shapely.geometry as sg
 import xarray as xr
 from dask.delayed import Delayed, delayed
 
@@ -152,6 +153,35 @@ def complex_coherence(
         coherence = delayed(_compute_coherence)(numerator, denominator)
 
     return coherence
+
+
+def crop(data: xr.Dataset | xr.DataArray, geom: sg.Polygon) -> xr.Dataset:
+    """Crop a radar image or stack of radar images to the bounding box of an area of interest.
+
+    Parameters
+    ----------
+    data: xr.Dataset | xr.DataArray
+        The dataset or data array to be cropped in azimuth and range
+    geom: sg.Polygon
+        shapely.geometry.Polygon in radar coordinates of the area that should be kept, in [azimuth, range] format
+
+    Returns
+    -------
+    xr.Dataset | xr.DataArray
+        The dataset or data array cropped to the area of interest
+
+    Raises
+    ------
+    ValueError
+        If the azimuth or range coordinate does not exist in `data`
+    """
+    if not {"azimuth", "range"}.issubset(data.dims):
+        raise ValueError("The data must have azimuth and range dimensions.")
+
+    bounding_box = geom.bounds  # returns (min_az, min_r, max_az, max_r)
+    data = data.sel(azimuth=range(bounding_box[0], bounding_box[2]+1), range=range(bounding_box[1], bounding_box[3]+1))
+
+    return data
 
 
 def _validate_multi_look_inputs(data, window_size, method, statistics):

--- a/sarxarray/utils.py
+++ b/sarxarray/utils.py
@@ -181,8 +181,8 @@ def crop(data: xr.Dataset | xr.DataArray, geom: sg.Polygon) -> xr.Dataset:
 
     bounding_box = geom.bounds  # returns (min_az, min_r, max_az, max_r)
     data = data.sel(
-        azimuth=range(bounding_box[0], bounding_box[2]+1),
-        range=range(bounding_box[1], bounding_box[3]+1)
+        azimuth=range(int(bounding_box[0]), int(np.ceil(bounding_box[2]))+1),
+        range=range(int(bounding_box[1]), int(np.ceil(bounding_box[3]))+1)
     )
 
     return data

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -38,8 +38,13 @@ def crop_geometry():
         [606, 1408],
         [606, 1409],
         [603, 1409],
-        [602, 1405]
+        [601.9, 1405]
     ])
+
+# Create a bounding box for cropping
+@pytest.fixture
+def crop_geometry_bbox():
+    return (601.9, 1405, 606, 1409)
 
 # this class tests multi_look with dataarray. For testing with dataset, see
 # test_stack.py
@@ -292,9 +297,17 @@ class TestUtilsCoherence:
 
 
 class TestUtilsCrop:
-    def test_crop(self, synthetic_dataarray, crop_geometry):
+    def test_crop_poly(self, synthetic_dataarray, crop_geometry):
         da = synthetic_dataarray
         geom = crop_geometry
+        da_crop = crop(da, geom)
+        assert da_crop.azimuth.size == 6
+        assert da_crop.range.size == 5
+        assert da_crop.time.size == da.time.size
+
+    def test_crop_bbox(self, synthetic_dataarray, crop_geometry_bbox):
+        da = synthetic_dataarray
+        geom = crop_geometry_bbox
         da_crop = crop(da, geom)
         assert da_crop.azimuth.size == 6
         assert da_crop.range.size == 5
@@ -304,5 +317,39 @@ class TestUtilsCrop:
         da = synthetic_dataarray
         da = da.rename({"azimuth": "az"})  # rename azimuth to a wrong name
         geom = crop_geometry
+        with pytest.raises(ValueError):
+            _ = crop(da, geom)
+
+    def test_crop_bbox_wrong_length(self, synthetic_dataarray, crop_geometry_bbox):
+        da = synthetic_dataarray
+        geom = crop_geometry_bbox[:3]
+        with pytest.raises(AssertionError):
+            _ = crop(da, geom)
+
+    def test_crop_bbox_wrong_az(self, synthetic_dataarray, crop_geometry_bbox):
+        da = synthetic_dataarray
+        geom = (  # swap min and max azimuth
+            crop_geometry_bbox[2],
+            crop_geometry_bbox[1],
+            crop_geometry_bbox[0],
+            crop_geometry_bbox[3]
+        )
+        with pytest.raises(AssertionError):
+            _ = crop(da, geom)
+
+    def test_crop_bbox_wrong_r(self, synthetic_dataarray, crop_geometry_bbox):
+        da = synthetic_dataarray
+        geom = (  # swap min and max range
+            crop_geometry_bbox[0],
+            crop_geometry_bbox[3],
+            crop_geometry_bbox[2],
+            crop_geometry_bbox[1]
+        )
+        with pytest.raises(AssertionError):
+            _ = crop(da, geom)
+
+    def test_crop_bbox_wrong_geom_type(self, synthetic_dataarray, crop_geometry_bbox):
+        da = synthetic_dataarray
+        geom = list(crop_geometry_bbox)
         with pytest.raises(ValueError):
             _ = crop(da, geom)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -305,4 +305,4 @@ class TestUtilsCrop:
         da = da.rename({"azimuth": "az"})  # rename azimuth to a wrong name
         geom = crop_geometry
         with pytest.raises(ValueError):
-            da_crop = crop(da, geom)
+            _ = crop(da, geom)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,11 +2,13 @@ import numpy as np
 import pytest
 import xarray as xr
 from dask.delayed import Delayed
+from shapely.geometry import Polygon
 
 from sarxarray.utils import (
     _get_chunks,
     _validate_multi_look_inputs,
     complex_coherence,
+    crop,
     multi_look,
 )
 
@@ -27,6 +29,17 @@ def synthetic_dataarray():
         },
     )
 
+# Create a polygon for cropping
+@pytest.fixture
+def crop_geometry():
+    return Polygon([
+        [601.9, 1405],
+        [605, 1407],
+        [606, 1408],
+        [606, 1409],
+        [603, 1409],
+        [602, 1405]
+    ])
 
 # this class tests multi_look with dataarray. For testing with dataset, see
 # test_stack.py
@@ -276,3 +289,13 @@ class TestUtilsCoherence:
             complex_coherence(reference, other1, window_size=(2, 2), compute=True)
         with pytest.raises(ValueError):
             complex_coherence(reference, other2, window_size=(2, 2), compute=True)
+
+
+class TestUtilsCrop:
+    def test_crop(self, synthetic_dataarray, crop_geometry):
+        da = synthetic_dataarray
+        geom = crop_geometry
+        da_crop = crop(da, geom)
+        assert da_crop.azimuth.size == 6
+        assert da_crop.range.size == 5
+        assert da_crop.time.size == da.time.size

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -299,3 +299,10 @@ class TestUtilsCrop:
         assert da_crop.azimuth.size == 6
         assert da_crop.range.size == 5
         assert da_crop.time.size == da.time.size
+
+    def test_crop_wrong_dimname(self, synthetic_dataarray, crop_geometry):
+        da = synthetic_dataarray
+        da = da.rename({"azimuth": "az"})  # rename azimuth to a wrong name
+        geom = crop_geometry
+        with pytest.raises(ValueError):
+            da_crop = crop(da, geom)


### PR DESCRIPTION
- adds cropping function based on the bounding box of a provided polygon in radar coordinates
- adds unit test
- adds dependency to `shapely` for geometry

Necessary for #85 

For TU Delft specific workflow, radarcoding is incorporated in the `DePSI` package already. By keeping it there, it saves having to include radarcoding and polygon reading natively in `sarxarray`.

The Dataset or DataArray remains in grid format, hence the bounding box (min/max azimuth, min/max range) is used instead of a perfect cutout. 