### PR TITLE
PR suggestions for from_znap_dataset

### DIFF
--- a/sarxarray/_io.py
+++ b/sarxarray/_io.py
@@ -287,6 +287,9 @@ def from_snap_dataset(snap_znap_archives: list[str, Path]) -> xr.Dataset:
         if is_mother:
             ds_stack = ds_stack.assign_attrs({"mother_epoch": epoch})
 
+    # sort ds_stack by time
+    ds_stack = ds_stack.sortby("time")
+
     # order epoch_file_dict by epoch
     epoch_file_dict = dict(sorted(epoch_file_dict.items()))
 

--- a/sarxarray/_io.py
+++ b/sarxarray/_io.py
@@ -240,13 +240,9 @@ def from_snap_dataset(snap_znap_archives: list[str, Path]) -> xr.Dataset:
     if len(snap_znap_archives) == 0:
         raise ValueError("snap_znap_archives should be a non-empty Iterable.")
 
-    # in the .znaps, the dimension x is range, y is azimuth
-    # xt and yt are interpolated values at coarse resolution
-    ds_stack = None
-    is_mother = False
-    data_mother = None
-
     # Loop over all ZNAP archives and read into ds_stack
+    ds_stack = None
+    data_mother = None
     for file in snap_znap_archives:
         # Read the ZNAP archive and check if it is a mother epoch
         data, is_mother = _read_one_znap_archive(file)
@@ -309,31 +305,31 @@ def from_snap_dataset(snap_znap_archives: list[str, Path]) -> xr.Dataset:
         logger.warning(warning_msg)
         metadata_file = f"{snap_znap_archives[0]}/SNAP/product_metadata.json"
         metadata = read_metadata(metadata_file, driver="snap")
-
-    # Assign the metadata to the ds_stack attributes
+    # Assign the metadata to ds_stack.attrs["metadata_mother"]
     ds_stack = ds_stack.assign_attrs({"metadata_mother": metadata})
 
-    # Rename the coordinates to azimuth and range
-    ds_stack = ds_stack.rename({"y": "azimuth", "x": "range"})
-
-    # Re-order dimensions to community preferred ("azimuth", "range", "time") order
-    ds_stack = ds_stack.transpose("azimuth", "range", "time")
-
-    # Shift the azimuth and range coordinates by offset
-    ds_stack = ds_stack.assign_coords(
-        azimuth=ds_stack["azimuth"] + metadata["first_line_number"],
-        range=ds_stack["range"] + metadata["first_pixel_number"],
+    # Rename and enforce the order of dimensions
+    ds_stack = (
+        ds_stack.rename(
+            {"y": "azimuth", "x": "range"}
+        ).transpose(  # rename the dimensions
+            "azimuth", "range", "time"
+        )  # enforce the order of dimensions
     )
 
-    # Assign complex
-    ds_stack = ds_stack.assign({"complex": ds_stack["i"] + 1j * ds_stack["q"]})
+    # Get the complex data variable
+    ds_stack = (
+        ds_stack.assign_coords(
+            azimuth=ds_stack["azimuth"] + metadata["first_line_number"],
+            range=ds_stack["range"] + metadata["first_pixel_number"],
+        )  # shift the azimuth and range coordinates by offset
+        .assign({"complex": ds_stack["i"] + 1j * ds_stack["q"]})  # assign complex
+        .drop_vars(["i", "q"])  # drop the original i and q variables
+    )
 
     # Calculate amplitude and phase from complex
     ds_stack = ds_stack.slcstack._get_amplitude()
     ds_stack = ds_stack.slcstack._get_phase()
-
-    # Drop the original i and q variables, as they are no longer needed
-    ds_stack = ds_stack.drop_vars(["i", "q"])
 
     return ds_stack
 

--- a/sarxarray/_io.py
+++ b/sarxarray/_io.py
@@ -253,34 +253,33 @@ def from_snap_dataset(snap_znap_archives: list[str, Path]) -> xr.Dataset:
         dims_non_xy = [dim for dim in data.dims if dim not in ["x", "y"]]
         data = data.drop_dims(dims_non_xy)  # Drop all non-x/y dims
 
+        # Get current epoch
         cur_epoch = data.attrs["time_coverage_start"]
         time_stamp = datetime.strptime(cur_epoch, "%Y-%m-%dT%H:%M:%S.%fZ")
         epoch = time_stamp.strftime("%Y%m%d")
 
         # Rename the data variables according to RE_PATTERNS_SNAP_DATALAYER
-        cleaned_data_layer = {}
+        cleaned_data_layers = {}
         for layer in data.data_vars.keys():
             cleaned_name = layer
             for key, pattern in RE_PATTERNS_SNAP_DATALAYER.items():
                 if re.match(pattern, layer):
                     cleaned_name = key
-            cleaned_data_layer[cleaned_name] = layer
+            cleaned_data_layers[cleaned_name] = layer
 
+        # Assign data
         full_data[epoch] = {
             "data": data,
-            "cleaned_data_layers": cleaned_data_layer,
+            "cleaned_data_layers": cleaned_data_layers,
             "filename": file,
         }
 
-    # Guess mother epoch in full_data by looking for a layer with lat/lon/elev
-    for epoch, data_dict in full_data.items():
-        data = data_dict["data"]
+        # Check if mother epoch
         if any(
-            layer in data.data_vars.keys()
+            layer in cleaned_data_layers
             for layer in ["latitude", "longitude", "elevation"]
         ):
             mother_epoch = epoch
-            break
 
     # sort the provided files chronologically
     sorted_epochs = list(sorted(list(full_data.keys())))

--- a/sarxarray/_io.py
+++ b/sarxarray/_io.py
@@ -858,7 +858,7 @@ def _regulate_metadata(metadata, driver):
     return metadata
 
 
-def _read_one_znap_archive(file: str | Path) -> (xr.Dataset, bool):
+def _read_one_znap_archive(file: str | Path) -> tuple[xr.Dataset, bool]:
     """Read a single ZNAP archive produced by SNAP and flag if mother."""
     # Initialize is_mother flag
     is_mother = False

--- a/sarxarray/_io.py
+++ b/sarxarray/_io.py
@@ -30,6 +30,7 @@ from .conf import (
     TIME_FORMAT_DORIS5,
     TIME_FORMAT_SNAP,
     TIME_STAMP_KEY,
+    ZNAP_DATA_VAR_MOTHER,
     _dtypes,
     _memsize_chunk_mb,
 )
@@ -241,173 +242,89 @@ def from_snap_dataset(snap_znap_archives: list[str, Path]) -> xr.Dataset:
 
     # in the .znaps, the dimension x is range, y is azimuth
     # xt and yt are interpolated values at coarse resolution
-    full_data = {}
-    mother_epoch = None
+    ds_stack = None
+    is_mother = False
 
+    # Loop over all ZNAP archives and read into ds_stack
     for file in snap_znap_archives:
-        # open one ZNAP archive
-        data = xr.open_zarr(file, consolidated=False)
-
-        # there are two types of layers: full data layers [x, y], and tiepoint [xt, yt]
-        # we only preserve the full data layers, as the others cannot be placed
-        dims_non_xy = [dim for dim in data.dims if dim not in ["x", "y"]]
-        data = data.drop_dims(dims_non_xy)  # Drop all non-x/y dims
+        # Read the ZNAP archive and check if it is a mother epoch
+        data, is_mother = _read_one_znap_archive(file)
 
         # Get current epoch
         cur_epoch = data.attrs["time_coverage_start"]
         time_stamp = datetime.strptime(cur_epoch, "%Y-%m-%dT%H:%M:%S.%fZ")
         epoch = time_stamp.strftime("%Y%m%d")
 
-        # Rename the data variables according to RE_PATTERNS_SNAP_DATALAYER
-        cleaned_data_layers = {}
-        for layer in data.data_vars.keys():
-            cleaned_name = layer
-            for key, pattern in RE_PATTERNS_SNAP_DATALAYER.items():
-                if re.match(pattern, layer):
-                    cleaned_name = key
-            cleaned_data_layers[cleaned_name] = layer
+        # If mother epoch
+        # keep variables ZNAP_DATA_VAR_MOTHER separately
+        # Assign an all zero h2ph variable
+        if is_mother:
+            data_mother = data[ZNAP_DATA_VAR_MOTHER]
+            data = data.drop_vars(ZNAP_DATA_VAR_MOTHER)
+            data = data.assign(
+                {"h2ph": (("y", "x"), np.zeros((data.sizes["y"], data.sizes["x"])))}
+            )
 
-        # Assign data
-        full_data[epoch] = {
-            "data": data,
-            "cleaned_data_layers": cleaned_data_layers,
-            "filename": file,
-        }
+        # Assign to ds_stack along the time dimension
+        if ds_stack is None:  # first epoch, initialize ds_stack
+            ds_stack = data.expand_dims(time=[time_stamp])
+            # Drop attrs inherited from the first epoch
+            ds_stack.attrs = {}
+            # Always initialize mother_epoch to None
+            # If first epoch is mother, it will be set to epoch below
+            ds_stack = ds_stack.assign_attrs({"mother_epoch": None})
+        else:
+            ds_stack = xr.concat(
+                [ds_stack, data.expand_dims(time=[time_stamp])],
+                dim="time",
+                combine_attrs="override",  # override the attrs of the first epoch
+            )
 
-        # Check if mother epoch
-        if any(
-            layer in cleaned_data_layers
-            for layer in ["latitude", "longitude", "elevation"]
-        ):
-            mother_epoch = epoch
+        # Modify the ds_stack if mother epoch
+        if is_mother:
+            ds_stack = ds_stack.assign_attrs({"mother_epoch": epoch})
 
-    # sort the provided files chronologically
-    sorted_epochs = list(sorted(list(full_data.keys())))
+    # Assign the mother epoch data to ds_stack
+    ds_stack = ds_stack.assign(data_mother)
 
-    # fallback for when mother epoch is not in the stack
-    if mother_epoch is None:
+    # Read the metadata from the mother epoch if it exists
+    if ds_stack.attrs["mother_epoch"] is not None:
+        ds_stack.attrs["mother_epoch"] = epoch
+        metadata_file = f"{file}/SNAP/product_metadata.json"
+        metadata = read_metadata(metadata_file, driver="snap")
+    else:
         warning_msg = (
-            f"Mother has not been identified. Using first epoch {sorted_epochs[0]} "
-            "for metadata instead."
+            "Mother epoch has not been identified. "
+            "Using first epoch for metadata instead."
         )
         logger.warning(warning_msg)
-        mother_epoch = sorted_epochs[0]
-    daughter_epochs = [epoch for epoch in sorted_epochs if epoch != mother_epoch]
+        metadata_file = f"{snap_znap_archives[0]}/SNAP/product_metadata.json"
+        metadata = read_metadata(metadata_file, driver="snap")
 
-    # read metadata to find the azimuth and range coordinate offsets
-    metadata_file = f"{full_data[mother_epoch]['filename']}/SNAP/product_metadata.json"
-    metadata = read_metadata(metadata_file, driver="snap")
+    # Assign the metadata to the ds_stack attributes
+    ds_stack = ds_stack.assign_attrs({"metadata_mother": metadata})
 
-    #  Initialize stack as a Dataset
-    coords = {
-        "azimuth": range(
-            metadata["first_line_number"],
-            metadata["first_line_number"] + metadata["number_of_lines"],
-        ),
-        "range": range(
-            metadata["first_pixel_number"],
-            metadata["first_pixel_number"] + metadata["number_of_pixels"],
-        ),
-        "time": sorted_epochs,
-    }
-    ds_stack = xr.Dataset(coords=coords)
+    # Rename the coordinates to azimuth and range
+    ds_stack = ds_stack.rename({"y": "azimuth", "x": "range"})
 
-    # handle the complex data, i = real, q = complex
-    slcs = None
-    for epoch in sorted_epochs:
-        cplx = (
-            full_data[epoch]["data"][full_data[epoch]["cleaned_data_layers"]["i"]].data
-            + 1j
-            * full_data[epoch]["data"][
-                full_data[epoch]["cleaned_data_layers"]["q"]
-            ].data
-        )
+    # Re-order dimensions to community preferred ("azimuth", "range", "time") order
+    ds_stack = ds_stack.transpose("azimuth", "range", "time")
 
-        if slcs is None:
-            slc = cplx.reshape(
-                (metadata["number_of_lines"], metadata["number_of_pixels"], 1)
-            )
-            slcs = slc
-        else:
-            slc = cplx.reshape(
-                (metadata["number_of_lines"], metadata["number_of_pixels"], 1)
-            )
-            slcs = da.concatenate([slcs, slc], axis=2)
+    # Shift the azimuth and range coordinates by offset
+    ds_stack = ds_stack.assign_coords(
+        azimuth=ds_stack["azimuth"] + metadata["first_line_number"],
+        range=ds_stack["range"] + metadata["first_pixel_number"],
+    )
 
-    ds_stack = ds_stack.assign({"complex": (("azimuth", "range", "time"), slcs)})
+    # Assign complex
+    ds_stack = ds_stack.assign({"complex": ds_stack["i"] + 1j * ds_stack["q"]})
 
-    # retain the additional layers in the daughter znaps (which are time-variant)
-    if len(daughter_epochs) > 0:
-        for layer in full_data[daughter_epochs[0]]["cleaned_data_layers"].keys():
-            if layer in ["i", "q"]:
-                continue  # these are handled separately above
-            layer_data = None
-            for epoch in sorted_epochs:
-                if layer_data is None:
-                    if layer not in full_data[epoch]["cleaned_data_layers"].keys():
-                        # e.g. it does not exist in the mother epoch, so we add zeros
-                        layer_data = da.zeros(
-                            (
-                                metadata["number_of_lines"],
-                                metadata["number_of_pixels"],
-                                1,
-                            )
-                        )
-                    else:
-                        layer_data = full_data[epoch]["data"][
-                            full_data[epoch]["cleaned_data_layers"][layer]
-                        ].data
-                        layer_data = layer_data.reshape(
-                            (
-                                metadata["number_of_lines"],
-                                metadata["number_of_pixels"],
-                                1,
-                            )
-                        )
-                else:
-                    if layer not in full_data[epoch]["cleaned_data_layers"].keys():
-                        # e.g. it does not exist in the mother epoch, so we add zeros
-                        cur_layer_data = da.zeros(
-                            (
-                                metadata["number_of_lines"],
-                                metadata["number_of_pixels"],
-                                1,
-                            )
-                        )
-                    else:
-                        cur_layer_data = full_data[epoch]["data"][
-                            full_data[epoch]["cleaned_layer_names"][layer]
-                        ].data
-                        cur_layer_data = cur_layer_data.reshape(
-                            (
-                                metadata["number_of_lines"],
-                                metadata["number_of_pixels"],
-                                1,
-                            )
-                        )
-                    layer_data = da.concatenate([layer_data, cur_layer_data], axis=2)
-
-            ds_stack = ds_stack.assign(
-                {layer: (("azimuth", "range", "time"), layer_data)}
-            )
-
-    # retain the additional layers in the mother znap (which is time-invariant)
-    for layer in full_data[mother_epoch]["cleaned_data_layers"].keys():
-        if layer in ds_stack.data_vars.keys() or layer in ["i", "q"]:
-            continue  # these are already included
-        ds_stack = ds_stack.assign(
-            {
-                layer: (
-                    ("azimuth", "range"),
-                    full_data[mother_epoch]["data"][
-                        full_data[mother_epoch]["cleaned_data_layers"][layer]
-                    ].data,
-                )
-            }
-        )
-
+    # Calculate amplitude and phase from complex
     ds_stack = ds_stack.slcstack._get_amplitude()
     ds_stack = ds_stack.slcstack._get_phase()
+
+    # Drop the original i and q variables, as they are no longer needed
+    ds_stack = ds_stack.drop_vars(["i", "q"])
 
     return ds_stack
 
@@ -928,8 +845,33 @@ def _regulate_metadata(metadata, driver):
     return metadata
 
 
-# def _regulate_znap_layer_name(orig_name:str, cleaned_name:str):
-#     cleaned_name = orig_name
-#     cleaned_name = cleaned_name.replace(f"_{cur_epoch}", "")
-#     for pol in ["VV", "VH", "HH", "HV"]:
-#         cleaned_name = cleaned_name.replace(f"_{pol}", "")
+def _read_one_znap_archive(file: str | Path) -> (xr.Dataset, bool):
+    """Read a single ZNAP archive produced by SNAP and flag if mother."""
+    # Initialize is_mother flag
+    is_mother = False
+
+    # open one ZNAP archive
+    data = xr.open_zarr(file, consolidated=False)
+
+    # there are two types of layers: full data layers [x, y], and tiepoint [xt, yt]
+    # we only preserve the full data layers, as the others cannot be placed
+    # drop all non-x/y dims, this also drops tiepoint vars
+    dims_non_xy = [dim for dim in data.dims if dim not in ["x", "y"]]
+    data = data.drop_dims(dims_non_xy)
+
+    # Rename the data variables according to RE_PATTERNS_SNAP_DATALAYER
+    for layer in data.data_vars.keys():
+        for key, pattern in RE_PATTERNS_SNAP_DATALAYER.items():
+            if re.match(pattern, layer):
+                data = data.rename({layer: key})
+        # Check if mother epoch
+        if any(layer in data.data_vars.keys() for layer in ZNAP_DATA_VAR_MOTHER):
+            is_mother = True
+
+    # Assign indices as coordinates to x and y
+    # This facilitates the concatenation
+    data = data.assign_coords(
+        {"x": range(data.sizes["x"]), "y": range(data.sizes["y"])}
+    )
+
+    return data, is_mother

--- a/sarxarray/_io.py
+++ b/sarxarray/_io.py
@@ -228,7 +228,7 @@ def from_snap_dataset(snap_znap_archives: list[str, Path]) -> xr.Dataset:
     """
     # Check if snap_znap_archives is a non empty Iterable and not a string
     if not hasattr(snap_znap_archives, "__iter__") or isinstance(
-            snap_znap_archives, str
+        snap_znap_archives, str
     ):
         raise ValueError(
             "snap_znap_archives should be a non-empty Iterable and not a string."
@@ -245,12 +245,13 @@ def from_snap_dataset(snap_znap_archives: list[str, Path]) -> xr.Dataset:
 
     for file in snap_znap_archives:
         data = xr.open_zarr(file, consolidated=False)
-        data_layers = data.original_raster_data_node_order
-        cur_epoch = data_layers[0].split("_")[-1]
-        epoch = datetime.strptime(cur_epoch, "%d%b%Y").strftime("%Y%m%d")
+        cur_epoch = data.attrs["time_coverage_start"]
+        time_stamp = datetime.strptime(cur_epoch, "%Y-%m-%dT%H:%M:%S.%fZ")
+        epoch = time_stamp.strftime("%Y%m%d")
 
         # there are two types of layers: full data layers [x, y], and tiepoint [xt, yt]
         # we only preserve the full data layers, as the others cannot be placed
+        data_layers = data.attrs["original_raster_data_node_order"]
         cleaned_data_layer = {}
         for layer in data_layers:
             dims = data[layer].dims
@@ -261,15 +262,16 @@ def from_snap_dataset(snap_znap_archives: list[str, Path]) -> xr.Dataset:
                     cleaned_name = cleaned_name.replace(f"_{pol}", "")
 
                 cleaned_data_layer[cleaned_name] = layer
-                if cleaned_name in [
-                    "latitude", "longitude", "elevation"
-                ] and mother_epoch is None:  # these are expected only at the mother
+                if (
+                    cleaned_name in ["latitude", "longitude", "elevation"]
+                    and mother_epoch is None
+                ):  # these are expected only at the mother
                     mother_epoch = epoch
 
         full_data[epoch] = {
             "data": data,
             "cleaned_data_layers": cleaned_data_layer,
-            "filename": file
+            "filename": file,
         }
 
     # sort the provided files chronologically
@@ -293,11 +295,11 @@ def from_snap_dataset(snap_znap_archives: list[str, Path]) -> xr.Dataset:
     coords = {
         "azimuth": range(
             metadata["first_line_number"],
-            metadata["first_line_number"] + metadata["number_of_lines"]
+            metadata["first_line_number"] + metadata["number_of_lines"],
         ),
         "range": range(
             metadata["first_pixel_number"],
-            metadata["first_pixel_number"] + metadata["number_of_pixels"]
+            metadata["first_pixel_number"] + metadata["number_of_pixels"],
         ),
         "time": sorted_epochs,
     }
@@ -308,8 +310,10 @@ def from_snap_dataset(snap_znap_archives: list[str, Path]) -> xr.Dataset:
     for epoch in sorted_epochs:
         cplx = (
             full_data[epoch]["data"][full_data[epoch]["cleaned_data_layers"]["i"]].data
-            + 1j *
-            full_data[epoch]["data"][full_data[epoch]["cleaned_data_layers"]["q"]].data
+            + 1j
+            * full_data[epoch]["data"][
+                full_data[epoch]["cleaned_data_layers"]["q"]
+            ].data
         )
 
         if slcs is None:
@@ -339,7 +343,7 @@ def from_snap_dataset(snap_znap_archives: list[str, Path]) -> xr.Dataset:
                             (
                                 metadata["number_of_lines"],
                                 metadata["number_of_pixels"],
-                                1
+                                1,
                             )
                         )
                     else:
@@ -350,7 +354,7 @@ def from_snap_dataset(snap_znap_archives: list[str, Path]) -> xr.Dataset:
                             (
                                 metadata["number_of_lines"],
                                 metadata["number_of_pixels"],
-                                1
+                                1,
                             )
                         )
                 else:
@@ -360,7 +364,7 @@ def from_snap_dataset(snap_znap_archives: list[str, Path]) -> xr.Dataset:
                             (
                                 metadata["number_of_lines"],
                                 metadata["number_of_pixels"],
-                                1
+                                1,
                             )
                         )
                     else:
@@ -371,12 +375,10 @@ def from_snap_dataset(snap_znap_archives: list[str, Path]) -> xr.Dataset:
                             (
                                 metadata["number_of_lines"],
                                 metadata["number_of_pixels"],
-                                1
+                                1,
                             )
                         )
-                    layer_data = da.concatenate(
-                        [layer_data, cur_layer_data], axis=2
-                    )
+                    layer_data = da.concatenate([layer_data, cur_layer_data], axis=2)
 
             ds_stack = ds_stack.assign(
                 {layer: (("azimuth", "range", "time"), layer_data)}
@@ -392,7 +394,7 @@ def from_snap_dataset(snap_znap_archives: list[str, Path]) -> xr.Dataset:
                     ("azimuth", "range"),
                     full_data[mother_epoch]["data"][
                         full_data[mother_epoch]["cleaned_data_layers"][layer]
-                    ].data
+                    ].data,
                 )
             }
         )
@@ -404,10 +406,10 @@ def from_snap_dataset(snap_znap_archives: list[str, Path]) -> xr.Dataset:
 
 
 def to_binary(
-        output_path: str,
-        data: xr.Dataset | xr.DataArray,
-        data_var_name: str | None = None,
-        allow_overwrite: bool = False
+    output_path: str,
+    data: xr.Dataset | xr.DataArray,
+    data_var_name: str | None = None,
+    allow_overwrite: bool = False,
 ):
     """Write a zarr data layer to a binary file.
 
@@ -439,7 +441,7 @@ def to_binary(
         - When `data` is not an `xr.Dataset` or `xr.DataArray`
 
     KeyError
-        When `data` is an `xr.Dataset` and `data_var_name` is not a data variable in 
+        When `data` is an `xr.Dataset` and `data_var_name` is not a data variable in
         `data`
 
     OSError
@@ -461,10 +463,7 @@ def to_binary(
 
     # Create the memmap
     memmap = np.memmap(
-        output_path,
-        dtype=datalayer.dtype,
-        mode="w+",
-        shape=datalayer.shape
+        output_path, dtype=datalayer.dtype, mode="w+", shape=datalayer.shape
     )
     # Assign the data to the memmap
     memmap[:] = datalayer.data[:]
@@ -771,7 +770,7 @@ def _flatten_snap_json_metadata(content: dict | list, cur_keys: tuple = ()):
     all_values = []
     if isinstance(content, list):
         for key in range(len(content)):
-            cur_keys_loop = cur_keys + (str(key), )
+            cur_keys_loop = cur_keys + (str(key),)
             part_values = _flatten_snap_json_metadata(content[key], cur_keys_loop)
             all_values = [*all_values, *part_values]
     elif isinstance(content, dict):
@@ -787,19 +786,19 @@ def _flatten_snap_json_metadata(content: dict | list, cur_keys: tuple = ()):
                 val = content["data"]["elems"][0]
             else:
                 val = content["data"]["elems"]
-            cur_keys_save = cur_keys + (content["name"], )
+            cur_keys_save = cur_keys + (content["name"],)
             all_values.append([val, cur_keys_save])
 
         else:
-            cur_keys_loop = cur_keys + (content["name"], )
+            cur_keys_loop = cur_keys + (content["name"],)
             if "elements" in content.keys():
-                cur_keys_loop_el = cur_keys_loop + ("elements", )
+                cur_keys_loop_el = cur_keys_loop + ("elements",)
                 part_values = _flatten_snap_json_metadata(
                     content["elements"], cur_keys_loop_el
                 )
                 all_values = [*all_values, *part_values]
             if "attributes" in content.keys():
-                cur_keys_loop_at = cur_keys_loop + ("attributes", )
+                cur_keys_loop_at = cur_keys_loop + ("attributes",)
                 part_values = _flatten_snap_json_metadata(
                     content["attributes"], cur_keys_loop_at
                 )

--- a/sarxarray/_io.py
+++ b/sarxarray/_io.py
@@ -243,6 +243,8 @@ def from_snap_dataset(snap_znap_archives: list[str, Path]) -> xr.Dataset:
     # Loop over all ZNAP archives and read into ds_stack
     ds_stack = None
     data_mother = None
+    metadata_file = None
+    epoch_file_dict = {}
     for file in snap_znap_archives:
         # Read the ZNAP archive and check if it is a mother epoch
         data, is_mother = _read_one_znap_archive(file)
@@ -251,6 +253,9 @@ def from_snap_dataset(snap_znap_archives: list[str, Path]) -> xr.Dataset:
         cur_epoch = data.attrs["time_coverage_start"]
         time_stamp = datetime.strptime(cur_epoch, "%Y-%m-%dT%H:%M:%S.%fZ")
         epoch = time_stamp.strftime("%Y%m%d")
+
+        # register the epoch and file in a dictionary for later use
+        epoch_file_dict[epoch] = file
 
         # If mother epoch
         # keep variables ZNAP_DATA_VAR_MOTHER separately
@@ -261,6 +266,7 @@ def from_snap_dataset(snap_znap_archives: list[str, Path]) -> xr.Dataset:
             data = data.assign(
                 {"h2ph": (("y", "x"), np.zeros((data.sizes["y"], data.sizes["x"])))}
             )
+            metadata_file = f"{file}/SNAP/product_metadata.json"
 
         # Assign to ds_stack along the time dimension
         if ds_stack is None:  # first epoch, initialize ds_stack
@@ -281,6 +287,9 @@ def from_snap_dataset(snap_znap_archives: list[str, Path]) -> xr.Dataset:
         if is_mother:
             ds_stack = ds_stack.assign_attrs({"mother_epoch": epoch})
 
+    # order epoch_file_dict by epoch
+    epoch_file_dict = dict(sorted(epoch_file_dict.items()))
+
     # Assign the mother epoch data to ds_stack
     if data_mother is not None:
         ds_stack = ds_stack.assign(data_mother)
@@ -293,9 +302,7 @@ def from_snap_dataset(snap_znap_archives: list[str, Path]) -> xr.Dataset:
         logger.warning(warning_msg)
 
     # Read the metadata from the mother epoch if it exists
-    if ds_stack.attrs["mother_epoch"] is not None:
-        ds_stack.attrs["mother_epoch"] = epoch
-        metadata_file = f"{file}/SNAP/product_metadata.json"
+    if metadata_file is not None:
         metadata = read_metadata(metadata_file, driver="snap")
     else:
         warning_msg = (
@@ -303,7 +310,8 @@ def from_snap_dataset(snap_znap_archives: list[str, Path]) -> xr.Dataset:
             "Using first epoch for metadata instead."
         )
         logger.warning(warning_msg)
-        metadata_file = f"{snap_znap_archives[0]}/SNAP/product_metadata.json"
+        file_first_epoch = list(epoch_file_dict.values())[0]
+        metadata_file = f"{file_first_epoch}/SNAP/product_metadata.json"
         metadata = read_metadata(metadata_file, driver="snap")
     # Assign the metadata to ds_stack.attrs["metadata_mother"]
     ds_stack = ds_stack.assign_attrs({"metadata_mother": metadata})

--- a/sarxarray/_io.py
+++ b/sarxarray/_io.py
@@ -873,14 +873,19 @@ def _read_one_znap_archive(file: str | Path) -> tuple[xr.Dataset, bool]:
     data = data.drop_dims(dims_non_xy)
 
     # Rename the data variables according to RE_PATTERNS_SNAP_DATALAYER
-    for layer in data.data_vars.keys():
+    for layer in list(data.data_vars):
         for key, pattern in RE_PATTERNS_SNAP_DATALAYER.items():
             if re.match(pattern, layer):
+                if key in data.data_vars and key != layer:
+                    raise ValueError(
+                        f"Multiple ZNAP datalayers match '{key}' after renaming (e.g. '{layer}'). "
+                        "Please provide a single polarisation/epoch per archive."
+                    )
                 data = data.rename({layer: key})
-        # Check if mother epoch
-        if any(layer in data.data_vars.keys() for layer in ZNAP_DATA_VAR_MOTHER):
-            is_mother = True
+                break
 
+    # Check if mother epoch
+    is_mother = any(v in data.data_vars for v in ZNAP_DATA_VAR_MOTHER)
     # Assign indices as coordinates to x and y
     # This facilitates the concatenation
     data = data.assign_coords(

--- a/sarxarray/_io.py
+++ b/sarxarray/_io.py
@@ -245,24 +245,26 @@ def from_snap_dataset(snap_znap_archives: list[str, Path]) -> xr.Dataset:
     mother_epoch = None
 
     for file in snap_znap_archives:
+        # open one ZNAP archive
         data = xr.open_zarr(file, consolidated=False)
+
+        # there are two types of layers: full data layers [x, y], and tiepoint [xt, yt]
+        # we only preserve the full data layers, as the others cannot be placed
+        dims_non_xy = [dim for dim in data.dims if dim not in ["x", "y"]]
+        data = data.drop_dims(dims_non_xy)  # Drop all non-x/y dims
+
         cur_epoch = data.attrs["time_coverage_start"]
         time_stamp = datetime.strptime(cur_epoch, "%Y-%m-%dT%H:%M:%S.%fZ")
         epoch = time_stamp.strftime("%Y%m%d")
 
-        # there are two types of layers: full data layers [x, y], and tiepoint [xt, yt]
-        # we only preserve the full data layers, as the others cannot be placed
-        data_layers = data.attrs["original_raster_data_node_order"]
+        # Rename the data variables according to RE_PATTERNS_SNAP_DATALAYER
         cleaned_data_layer = {}
-        for layer in data_layers:
-            dims = data[layer].dims
-            if "x" in dims and "y" in dims and len(dims) == 2:
-                # clean the layer name as RE_PATTERNS_SNAP_DATALAYER
-                for key, pattern in RE_PATTERNS_SNAP_DATALAYER.items():
-                    if re.match(pattern, layer):
-                        cleaned_name = key
-
-                cleaned_data_layer[cleaned_name] = layer
+        for layer in data.data_vars.keys():
+            cleaned_name = layer
+            for key, pattern in RE_PATTERNS_SNAP_DATALAYER.items():
+                if re.match(pattern, layer):
+                    cleaned_name = key
+            cleaned_data_layer[cleaned_name] = layer
 
         full_data[epoch] = {
             "data": data,

--- a/sarxarray/_io.py
+++ b/sarxarray/_io.py
@@ -876,11 +876,6 @@ def _read_one_znap_archive(file: str | Path) -> tuple[xr.Dataset, bool]:
     for layer in list(data.data_vars):
         for key, pattern in RE_PATTERNS_SNAP_DATALAYER.items():
             if re.match(pattern, layer):
-                if key in data.data_vars and key != layer:
-                    raise ValueError(
-                        f"Multiple ZNAP datalayers match '{key}' after renaming (e.g. '{layer}'). "
-                        "Please provide a single polarisation/epoch per archive."
-                    )
                 data = data.rename({layer: key})
                 break
 

--- a/sarxarray/_io.py
+++ b/sarxarray/_io.py
@@ -261,6 +261,15 @@ def from_snap_dataset(snap_znap_archives: list[str, Path]) -> xr.Dataset:
         # keep variables ZNAP_DATA_VAR_MOTHER separately
         # Assign an all zero h2ph variable
         if is_mother:
+            # check if mother epoch has already been found
+            if data_mother is not None:
+                raise ValueError(
+                    "Multiple mother epochs found. "
+                    "Please check the ZNAP archives."
+                    "Only one mother epoch can have the following variables: "
+                    f"{ZNAP_DATA_VAR_MOTHER}. "
+                )
+
             data_mother = data[ZNAP_DATA_VAR_MOTHER]
             data = data.drop_vars(ZNAP_DATA_VAR_MOTHER)
             data = data.assign(

--- a/sarxarray/_io.py
+++ b/sarxarray/_io.py
@@ -241,10 +241,10 @@ def from_snap_dataset(snap_znap_archives: list[str, Path]) -> xr.Dataset:
         raise ValueError("snap_znap_archives should be a non-empty Iterable.")
 
     # Loop over all ZNAP archives and read into ds_stack
-    ds_stack = None
-    data_mother = None
-    metadata_file = None
-    epoch_file_dict = {}
+    ds_stack = None  # Stack of all epochs as xr.Dataset
+    data_mother = None  # Mother epoch specific xr.Dataset
+    metadata_file = None  # Metadata file, read from mother epoch
+    epoch_file_dict = {}  # Map of epoch to file. snap_znap_archives may not be sorted
     for file in snap_znap_archives:
         # Read the ZNAP archive and check if it is a mother epoch
         data, is_mother = _read_one_znap_archive(file)

--- a/sarxarray/_io.py
+++ b/sarxarray/_io.py
@@ -25,6 +25,7 @@ from .conf import (
     RE_PATTERNS_DORIS5,
     RE_PATTERNS_DORIS5_IFG,
     RE_PATTERNS_SNAP,
+    RE_PATTERNS_SNAP_DATALAYER,
     TIME_FORMAT_DORIS4,
     TIME_FORMAT_DORIS5,
     TIME_FORMAT_SNAP,
@@ -256,23 +257,28 @@ def from_snap_dataset(snap_znap_archives: list[str, Path]) -> xr.Dataset:
         for layer in data_layers:
             dims = data[layer].dims
             if "x" in dims and "y" in dims and len(dims) == 2:
-                cleaned_name = layer
-                cleaned_name = cleaned_name.replace(f"_{cur_epoch}", "")
-                for pol in ["VV", "VH", "HH", "HV"]:
-                    cleaned_name = cleaned_name.replace(f"_{pol}", "")
+                # clean the layer name as RE_PATTERNS_SNAP_DATALAYER
+                for key, pattern in RE_PATTERNS_SNAP_DATALAYER.items():
+                    if re.match(pattern, layer):
+                        cleaned_name = key
 
                 cleaned_data_layer[cleaned_name] = layer
-                if (
-                    cleaned_name in ["latitude", "longitude", "elevation"]
-                    and mother_epoch is None
-                ):  # these are expected only at the mother
-                    mother_epoch = epoch
 
         full_data[epoch] = {
             "data": data,
             "cleaned_data_layers": cleaned_data_layer,
             "filename": file,
         }
+
+    # Guess mother epoch in full_data by looking for a layer with lat/lon/elev
+    for epoch, data_dict in full_data.items():
+        data = data_dict["data"]
+        if any(
+            layer in data.data_vars.keys()
+            for layer in ["latitude", "longitude", "elevation"]
+        ):
+            mother_epoch = epoch
+            break
 
     # sort the provided files chronologically
     sorted_epochs = list(sorted(list(full_data.keys())))
@@ -919,3 +925,10 @@ def _regulate_metadata(metadata, driver):
                     logger.warning(warning_msg)
 
     return metadata
+
+
+# def _regulate_znap_layer_name(orig_name:str, cleaned_name:str):
+#     cleaned_name = orig_name
+#     cleaned_name = cleaned_name.replace(f"_{cur_epoch}", "")
+#     for pol in ["VV", "VH", "HH", "HV"]:
+#         cleaned_name = cleaned_name.replace(f"_{pol}", "")

--- a/sarxarray/_io.py
+++ b/sarxarray/_io.py
@@ -244,6 +244,7 @@ def from_snap_dataset(snap_znap_archives: list[str, Path]) -> xr.Dataset:
     # xt and yt are interpolated values at coarse resolution
     ds_stack = None
     is_mother = False
+    data_mother = None
 
     # Loop over all ZNAP archives and read into ds_stack
     for file in snap_znap_archives:
@@ -285,7 +286,15 @@ def from_snap_dataset(snap_znap_archives: list[str, Path]) -> xr.Dataset:
             ds_stack = ds_stack.assign_attrs({"mother_epoch": epoch})
 
     # Assign the mother epoch data to ds_stack
-    ds_stack = ds_stack.assign(data_mother)
+    if data_mother is not None:
+        ds_stack = ds_stack.assign(data_mother)
+    else:
+        warning_msg = (
+            "Mother epoch has not been identified. "
+            f"The following variables {ZNAP_DATA_VAR_MOTHER} "
+            "are not present in any of the ZNAP archives. "
+        )
+        logger.warning(warning_msg)
 
     # Read the metadata from the mother epoch if it exists
     if ds_stack.attrs["mother_epoch"] is not None:

--- a/sarxarray/conf.py
+++ b/sarxarray/conf.py
@@ -226,3 +226,7 @@ TIME_FORMAT_SNAP = "timestamp"
 
 # Time stamp key
 TIME_STAMP_KEY = "first_azimuth_time"
+
+# SNAP Znap file data variable names
+ZNAP_DATA_VAR_MOTHER = ["longitude", "latitude", "elevation"]
+ZNAP_DATA_VAR_DAUGHTERS = ["i", "q", "h2ph"]

--- a/sarxarray/conf.py
+++ b/sarxarray/conf.py
@@ -64,13 +64,11 @@ RE_PATTERNS_DORIS5 = {
         r"\.\d+(?:\.\d+)?)\s+([-+]?\d+\.\d+(?:\.\d+)?)"
     ),
     "scene_centre_latitude": (
-        r"Scene_centre_latitude:"
-        r"\s+([-+]?\d+(?:\.\d+)?(?:[eE][-+]?\d+)?)"
+        r"Scene_centre_latitude:" r"\s+([-+]?\d+(?:\.\d+)?(?:[eE][-+]?\d+)?)"
     ),
     "scene_centre_longitude": (
-        r"Scene_centre_longitude:"
-        r"\s+([-+]?\d+(?:\.\d+)?(?:[eE][-+]?\d+)?)"
-    )
+        r"Scene_centre_longitude:" r"\s+([-+]?\d+(?:\.\d+)?(?:[eE][-+]?\d+)?)"
+    ),
 }
 # Regular expressions for reading metadata from DORIS5 interferogram files
 RE_PATTERNS_DORIS5_IFG = {
@@ -141,6 +139,12 @@ RE_PATTERNS_SNAP = {
     ),
     "first_line_number": r"[\d]+.Abstracted_Metadata.attributes.[\d]+.subset_offset_y",
 }
+# Regular expressions for renaming SNAP Zarr file (ZNAP) datalayers.
+RE_PATTERNS_SNAP_DATALAYER = {
+    "i": r"^i_(VV|VH|HH|HV)_\d{1,2}[A-Za-z]{3}\d{4}$",  # e.g., i_VV_19Mar2023
+    "q": r"^q_(VV|VH|HH|HV)_\d{1,2}[A-Za-z]{3}\d{4}$",  # e.g., q_VV_19Mar2023
+    "h2ph": r"^h2ph_(VV|VH|HH|HV)_\d{1,2}[A-Za-z]{3}\d{4}$",  # e.g., h2ph_VV_19Mar2023
+}
 # Float keys in metadata. They are used to regulate the metadata read as strings
 # Some of these are from DORIS5 only
 META_FLOAT_KEYS = [
@@ -156,7 +160,7 @@ META_FLOAT_KEYS = [
     "pulse_repetition_frequency_raw",
     "azimuth_time_interval",
     "scene_centre_latitude",
-    "scene_centre_longitude"
+    "scene_centre_longitude",
 ]
 # Integer keys in metadata. They are used to regulate the metadata read as strings
 META_INT_KEYS = [
@@ -200,7 +204,7 @@ META_UNIT_CONVERSION_MULTIPLICATION_KEYS_DORIS5 = {
 }
 
 META_UNIT_CONVERSION_MULTIPLICATION_KEYS_SNAP = {
-    "radar_frequency": 1_000_000, # originally MHz
+    "radar_frequency": 1_000_000,  # originally MHz
 }
 
 # Time formats for DORIS metadata

--- a/sarxarray/conf.py
+++ b/sarxarray/conf.py
@@ -143,11 +143,14 @@ RE_PATTERNS_SNAP = {
     "first_line_number": r"[\d]+.Abstracted_Metadata.attributes.[\d]+.subset_offset_y",
 }
 
-# Regular expressions for renaming SNAP Zarr file (ZNAP) datalayers.
+# Regular expressions for reading SNAP Zarr file (ZNAP) datalayers.
 RE_PATTERNS_SNAP_DATALAYER = {
     "i": r"^i_(VV|VH|HH|HV)_\d{1,2}[A-Za-z]{3}\d{4}$",  # e.g., i_VV_19Mar2023
     "q": r"^q_(VV|VH|HH|HV)_\d{1,2}[A-Za-z]{3}\d{4}$",  # e.g., q_VV_19Mar2023
     "h2ph": r"^h2ph_(VV|VH|HH|HV)_\d{1,2}[A-Za-z]{3}\d{4}$",  # e.g., h2ph_VV_19Mar2023
+    "longitude": r"^longitude_(VV|VH|HH|HV)$",  # e.g., longitude_VV
+    "latitude": r"^latitude_(VV|VH|HH|HV)$",  # e.g., latitude_VV
+    "elevation": r"^elevation_(VV|VH|HH|HV)$",  # e.g., elevation_VV
 }
 
 # Float keys in metadata. They are used to regulate the metadata read as strings

--- a/sarxarray/conf.py
+++ b/sarxarray/conf.py
@@ -26,6 +26,7 @@ RE_PATTERNS_DORIS4 = {
     "weighting_range": r"Weighting_range:\s+(.+)",
     "first_azimuth_time": r"First_pixel_azimuth_time \(UTC\):\s+(.+)",
 }
+
 # Regular expressions for reading metadata from DORIS5 files
 RE_PATTERNS_DORIS5 = {
     "sar_processor": r"SAR_PROCESSOR:\s+(.+)",
@@ -70,11 +71,13 @@ RE_PATTERNS_DORIS5 = {
         r"Scene_centre_longitude:" r"\s+([-+]?\d+(?:\.\d+)?(?:[eE][-+]?\d+)?)"
     ),
 }
+
 # Regular expressions for reading metadata from DORIS5 interferogram files
 RE_PATTERNS_DORIS5_IFG = {
     "number_of_lines": r"Number of lines \(multilooked\):\s+(\d+)",
     "number_of_pixels": r"Number of pixels \(multilooked\):\s+(\d+)",
 }
+
 # Regular expressions for reading metadata from SNAP
 RE_PATTERNS_SNAP = {
     "sar_processor": (
@@ -139,12 +142,14 @@ RE_PATTERNS_SNAP = {
     ),
     "first_line_number": r"[\d]+.Abstracted_Metadata.attributes.[\d]+.subset_offset_y",
 }
+
 # Regular expressions for renaming SNAP Zarr file (ZNAP) datalayers.
 RE_PATTERNS_SNAP_DATALAYER = {
     "i": r"^i_(VV|VH|HH|HV)_\d{1,2}[A-Za-z]{3}\d{4}$",  # e.g., i_VV_19Mar2023
     "q": r"^q_(VV|VH|HH|HV)_\d{1,2}[A-Za-z]{3}\d{4}$",  # e.g., q_VV_19Mar2023
     "h2ph": r"^h2ph_(VV|VH|HH|HV)_\d{1,2}[A-Za-z]{3}\d{4}$",  # e.g., h2ph_VV_19Mar2023
 }
+
 # Float keys in metadata. They are used to regulate the metadata read as strings
 # Some of these are from DORIS5 only
 META_FLOAT_KEYS = [
@@ -162,6 +167,7 @@ META_FLOAT_KEYS = [
     "scene_centre_latitude",
     "scene_centre_longitude",
 ]
+
 # Integer keys in metadata. They are used to regulate the metadata read as strings
 META_INT_KEYS = [
     "deramp",  # from here DORIS5 only
@@ -172,6 +178,7 @@ META_INT_KEYS = [
     "first_pixel_number",  # from here SNAP
     "first_line_number",
 ]
+
 # Array keys in metadata and their format. Requires re.findall instead of re.match
 # Expects 2D arrays, and a callable variable type as value associated with each key
 META_ARRAY_KEYS = {
@@ -181,6 +188,7 @@ META_ARRAY_KEYS = {
     "orbit_velocity": float,
     "polarisations": str,
 }
+
 # SNAP returns flattened 1D arrays, so we need to tell it the shapes. The auto
 # dimension gets expanded to the total number of inputs, and is required
 META_ARRAY_SHAPES_SNAP = {
@@ -189,6 +197,7 @@ META_ARRAY_SHAPES_SNAP = {
     "orbit_velocity": ("auto", 3),
     "polarisations": ("auto", 1),
 }
+
 # Some keys are not read in in SI units. The following dictionary specifies those
 # keys, and the factor they should be multiplied by to restore them to SI units
 META_UNIT_CONVERSION_MULTIPLICATION_KEYS_DORIS4 = {
@@ -211,5 +220,6 @@ META_UNIT_CONVERSION_MULTIPLICATION_KEYS_SNAP = {
 TIME_FORMAT_DORIS4 = "%d-%b-%Y %H:%M:%S.%f"
 TIME_FORMAT_DORIS5 = "%Y-%b-%d %H:%M:%S.%f"
 TIME_FORMAT_SNAP = "timestamp"
+
 # Time stamp key
 TIME_STAMP_KEY = "first_azimuth_time"

--- a/tests/data/zarrs/20230319-coreg.znap/.zattrs
+++ b/tests/data/zarrs/20230319-coreg.znap/.zattrs
@@ -5,8 +5,8 @@
   "product_description" : "Sentinel-1 IW Level-1 SLC Product",
   "product_scene_raster_width" : 338,
   "product_scene_raster_height" : 84,
-  "time_coverage_start" : "2023-03-31T05:50:35.812250Z",
-  "time_coverage_end" : "2023-03-31T05:50:35.983086Z",
+  "time_coverage_start" : "2023-03-19T05:50:35.812250Z",
+  "time_coverage_end" : "2023-03-19T05:50:35.983086Z",
   "geocoding" : {
     "TiePointGeoCoding" : {
       "___persistence_id___" : "TiePointGC:1",


### PR DESCRIPTION
- Mannually hacked the metadata of 20230319 to make the time reading correct
- Changed the code structure to build ds_stack along looping the zarr files
- Use ds.datetime as time coords
- Set RE patterns in config for naming patterns of zarr data variables (motivation: let's be specific on renaming behavior per variable, but not just remove the time and polarization pattern.)
- Added a check for multiple mothers (only one zarr storage can have mother specific variables)

Still need to be implemented:
- make data variable names flexible (e.g. not enforcing adding `h2ph`). This can be done by having an input arg for `from_snap_dataset`