### PR TITLE
switch to shield io for a stable rendering of zenodo doi badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SARXarray
 
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.7717027.svg)](https://doi.org/10.5281/zenodo.7717027)
+[![DOI](https://img.shields.io/badge/DOI-10.5281%2Fzenodo.7717027-blue.svg)](https://doi.org/10.5281/zenodo.7717027)
 [![PyPI](https://img.shields.io/pypi/v/sarxarray.svg?colorB=blue)](https://pypi.python.org/project/sarxarray/)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=TUDelftGeodesy_sarxarray&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=TUDelftGeodesy_sarxarray)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/7980/badge)](https://www.bestpractices.dev/projects/7980)


### PR DESCRIPTION
According to [Zenodo's blog](https://blog.zenodo.org/2026/05/21/2026-05-21-session-incident/), the caching policy has changed due to security reseans. This unfortunately also influenced how the rendering of Zenodo DOI badges. At present, the redering of DOI badges sometimes fail. By refreshing sometimes it works.

Inspired by [sklearn's fix](https://github.com/scikit-learn/scikit-learn/issues/33840), we can make a static badge using shields.io.